### PR TITLE
feat: tag to size function, uprev to 0.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = ["README.md", "pyproject.toml"]
 name = "struct_writer"
 readme = "README.md"
 repository = "https://github.com/drbartling/struct-writer"
-version = "0.5.4"
+version = "0.5.5"
 
 [tool.poetry.scripts]
 struct-writer = "struct_writer.generate_structured_code:main"

--- a/src/struct_writer/render_rust.py
+++ b/src/struct_writer/render_rust.py
@@ -271,12 +271,12 @@ match self{{
         payload_size = v["size"]
         s += f"{group_name}::{name}(_) => {enum_size + payload_size},\n"
 
-    s += """
-}
-}
+    s += f"""\
+}}
+}}
 
-pub fn tag_to_size(tag: u8) -> Option<usize> {
-match tag {
+pub fn tag_to_size(tag: u8) -> Option<usize> {{
+match tag {{
 """
 
     for k, v in group_elements.items():

--- a/src/struct_writer/render_rust.py
+++ b/src/struct_writer/render_rust.py
@@ -274,11 +274,26 @@ match self{{
     s += """
 }
 }
+
+pub fn tag_to_size(tag: u8) -> Option<usize> {
+match tag {
+"""
+
+    for k, v in group_elements.items():
+        name       = v["groups"][group_name]["name"]
+        tag_value  = v["groups"][group_name]["value"]
+        payload_size = v["size"]
+        total_size   = enum_size + payload_size
+        s += f"{tag_value:#04x} => Some({total_size}), // {group_name}::{name}\n"
+    s += f" _ => None,"
+    s += """\
+}
+}
 }
 """
 
     s += f"""\
-impl From<{group_name}> for {group_name}_slice {{
+impl From<{group_name}> for {group_name}Slice {{
 fn from(value: {group_name}) -> Self {{
 #[allow(unused_mut)]
 let mut buf = [0_u8; {type_size}];
@@ -292,7 +307,7 @@ match value {{
         end = enum_size + inner_size
         s += f"{group_name}::{name}(inner) => {{\n"
         s += f"buf[0..{enum_size}].copy_from_slice(&{value}_{repr_type}.to_le_bytes());\n"
-        s += f"let inner_buf: {k}_slice = inner.into();\n"
+        s += f"let inner_buf: {k}Slice = inner.into();\n"
         s += f"buf[{enum_size}..{end}].copy_from_slice(&inner_buf);\n"
         s += "}\n"
 
@@ -329,10 +344,10 @@ _ => Err(()),
 }}
 }}
 
-impl TryFrom<{group_name}_slice> for {group_name} {{
+impl TryFrom<{group_name}Slice> for {group_name} {{
 type Error = ();
 
-fn try_from(value: {group_name}_slice) -> Result<Self, Self::Error> {{
+fn try_from(value: {group_name}Slice) -> Result<Self, Self::Error> {{
 let r: &[u8] = &value;
 r.try_into()
 }}


### PR DESCRIPTION
Uprev to 0.5.5

Includes function to return size given a tag.

Minor syntax changes to reflect Rust style casing